### PR TITLE
This starts a port to OS X.

### DIFF
--- a/devices/posixfs.c
+++ b/devices/posixfs.c
@@ -55,7 +55,7 @@ Cell* posixfs_open(Cell* cpath) {
         
         printf("[posixfs] trying to read file of len %d…\r\n",len);
         Cell* res = alloc_num_bytes(len);
-        int read_len = fread(res->addr, len, 1, f);
+        int read_len = fread(res->addr, 1, len, f);
         // TODO: close?
         _file_cell = res;
         return res;

--- a/sledge/alloc.c
+++ b/sledge/alloc.c
@@ -1,5 +1,5 @@
 #include "alloc.h"
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include "stream.h"
 

--- a/sledge/build_x64.sh
+++ b/sledge/build_x64.sh
@@ -1,2 +1,8 @@
-gcc -g -o sledge --std=gnu99 -I. sledge.c reader.c writer.c alloc.c strmap.c stream.c ../devices/sdl2.c ../devices/posixfs.c -lm -lSDL2 -DCPU_X64 -DDEV_SDL -DDEV_POSIXFS
+#!/bin/sh
+
+if [ `uname` = "Darwin" ] ; then
+    CFLAGS="${CFLAGS} -I/opt/local/include -L/opt/local/lib"
+fi
+
+cc -g -o sledge --std=gnu99 -I. ${CFLAGS} sledge.c reader.c writer.c alloc.c strmap.c stream.c ../devices/sdl2.c ../devices/posixfs.c -lm -lSDL2 -DCPU_X64 -DDEV_SDL -DDEV_POSIXFS
 

--- a/sledge/compiler_x64_hosted.c
+++ b/sledge/compiler_x64_hosted.c
@@ -1,3 +1,7 @@
+#if defined(__APPLE__) && defined(__MACH__)
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
 //#define DEBUG
 
 Cell* execute_jitted(void* binary) {
@@ -34,7 +38,11 @@ int compile_for_platform(Cell* expr, Cell** res) {
     // prefix with arm-none-eabi- on ARM  -mlittle-endian
     
     system("as /tmp/jit_out.s -o /tmp/jit_out.o");
+#if defined(__APPLE__) && defined(__MACH__)
+    system("gobjcopy /tmp/jit_out.o -O binary /tmp/jit_out.bin");
+#else
     system("objcopy /tmp/jit_out.o -O binary /tmp/jit_out.bin");
+#endif
 
     FILE* binary_f = fopen("/tmp/jit_out.bin","r");
 

--- a/sledge/jit_x64.c
+++ b/sledge/jit_x64.c
@@ -167,7 +167,13 @@ void jit_divr(int dreg, int sreg) {
 
 void jit_call(void* func, char* note) {
   fprintf(jit_out, "mov $%p, %%rax\n", func);
+#if defined(__APPLE__) && defined(__MACH__)
+  fprintf(jit_out, "subq $8, %%rsp\n");
+#endif
   fprintf(jit_out, "callq *%%rax # %s\n", note);
+#if defined(__APPLE__) && defined(__MACH__)
+  fprintf(jit_out, "addq $8, %%rsp\n");
+#endif
 }
 
 void jit_callr(int reg) {

--- a/sledge/jit_x64.c
+++ b/sledge/jit_x64.c
@@ -85,10 +85,12 @@ void jit_str_stack(int sreg, int offset) {
 }
 
 void jit_inc_stack(int offset) {
+  if (offset == 0) return;
   fprintf(jit_out, "addq $%d, %%rsp\n", offset);
 }
 
 void jit_dec_stack(int offset) {
+  if (offset == 0) return;
   fprintf(jit_out, "subq $%d, %%rsp\n", offset);
 }
 

--- a/sledge/minilisp.h
+++ b/sledge/minilisp.h
@@ -5,6 +5,7 @@
 
 #include "strmap.h"
 
+#ifndef BLAND
 #define KNRM  "\x1B[0m"
 #define KRED  "\x1B[31m"
 #define KGRN  "\x1B[32m"
@@ -13,6 +14,16 @@
 #define KMAG  "\x1B[35m"
 #define KCYN  "\x1B[36m"
 #define KWHT  "\x1B[37m"
+#else
+#define KNRM  ""
+#define KRED  ""
+#define KGRN  ""
+#define KYEL  ""
+#define KBLU  ""
+#define KMAG  ""
+#define KCYN  ""
+#define KWHT  ""
+#endif
 
 #define TAG_FREED 0
 #define TAG_INT  1


### PR DESCRIPTION
Presently it doesn't work, because it can't eval shell.l. A function
is called with a NULL pointer for the first argument. Not sure yet
what the function is though.

Here's the present run:

[compiler] creating global env hash table…
[compiler] init_allocator…

++ cell heap at 0x10a000000, 240000000 bytes reserved
[allocator] initialized.
[compiler] inserting symbols…
[compiler] arithmetic…
[compiler] compare…
[compiler] flow…
[compiler] lists…
[compiler] strings…
[compiler] write/eval…
sledge knows 47 symbols. enter (symbols) to see them.
[fs] mounted: /framebuffer
[fs] mounted: /keyboard
[fs] mounted: /sd
sledge>
JIT ---------------------
movq $0x10a001f80, %rdi
mov $0x10000c730, %rax
subq $8, %rsp
callq *%rax # fs_open
addq $8, %rsp
movq %rax, %rdi
mov $0x10000ce90, %rax
subq $8, %rsp
callq *%rax # stream_read
addq $8, %rsp
movq %rax, %rdi
mov $0x100009d40, %rax
subq $8, %rsp
callq *%rax # read_string_cell
addq $8, %rsp
movq %rax, %rdi
mov $0x1000071d0, %rax
subq $8, %rsp
callq *%rax # platform_eval
addq $8, %rsp
ret
-------------------------

<assembled bytes: 100 at: 0x1091fb000>
warning: nm: no name list
[open] found matching fs: /sd for path: /sd/os/shell.l
[open] open_fn: 0x10000d8e0
filename: os/shell.l
[posixfs] trying to read file of len 13594…

JIT ---------------------
push %rdi
jmp f1_0x10a026910
f0_0x10a026910:
movq $0xf00000010a026911, %rsi
push %rsi
movq %r12, %rax
movq (%rax), %rax
cmp $0, %rax
je else_1
movq %r13, %rax
movq (%rax), %rax
cmp $0, %rax
je else_2
movq $0x10a0022b0, %rax
jmp endif_3
else_2:
movq $0x10a0022e0, %rax
endif_3:
jmp endif_4
else_1:
movq $0x10a002328, %rax
endif_4:
addq $8, %rsp
ret
f1_0x10a026910:
movq $0x10a026910, %rax
movq %rax, %rsi
pop %rdi
movq $0x10a0020e8, %rdi
mov $0x100001640, %rax
subq $8, %rsp
callq *%rax # insert_global_symbol
addq $8, %rsp
ret
-------------------------

<assembled bytes: 139 at: 0x1091fd000>
Process 90261 stopped
* thread #1: tid = 0x1e9cf6, 0x00000001091fd014, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x00000001091fd014
->  0x1091fd014: movq   (%rax), %rax
    0x1091fd017: cmpq   $0x0, %rax
    0x1091fd01b: je     0x1091fd021
    0x1091fd021: movq   %r13, %rax