### PR TITLE
Print final newline before exit

### DIFF
--- a/sledge/sledge.c
+++ b/sledge/sledge.c
@@ -137,6 +137,7 @@ int main(int argc, char *argv[])
       in_fd = 0;
       in_offset=0;
       if (feof(stdin)) {
+        printf("\n");
         exit(0);
       }
     }


### PR DESCRIPTION
Quitting sledge does not print a final newline which causes the prompt in bash to not be printed properly and emits a bright `%` on zsh.  The attached PR fixes this.  It doesn't appear to affect script mode, but I'm not 100% sure on that.