### PR TITLE
Fix Cons representation

### DIFF
--- a/sledge/writer.c
+++ b/sledge/writer.c
@@ -62,7 +62,7 @@ char* write_(Cell* cell, char* buffer, int in_list, int bufsize) {
       } else {
         write_((Cell*)cell->dr.next, tmpr, 0, TMP_BUF_SIZE);
         // improper list
-        snprintf(buffer, bufsize, "(%s.%s)", tmpl, tmpr);
+        snprintf(buffer, bufsize, "(%s . %s)", tmpl, tmpr);
       }
       free(tmpl);
       free(tmpr);


### PR DESCRIPTION
```
interim> (recv (open "/mouse"))
[open] via /mouse: /mouse
((0.0).0)
```

This looks wrong and would be mistaken for floats or symbols in other Lisp implementations.   Even though cons notation is not supported by the reader, changing the printer to display `((0 . 0) . 0)` will pave the way.