### PR TITLE
Bail out on too long symbols

### DIFF
--- a/sledge/compiler_new.c
+++ b/sledge/compiler_new.c
@@ -40,9 +40,14 @@ Cell* insert_symbol(Cell* symbol, Cell* cell, env_t** env) {
   }
     
   e = malloc(sizeof(env_entry));
-  memcpy(e->name, (char*)symbol->ar.addr, symbol->dr.size);
-  e->cell = cell;
+  int ret = snprintf(e->name, MAX_SYMBOL_SIZE, "%s", (char*)symbol->ar.addr);
+  if (ret >= MAX_SYMBOL_SIZE) {
+    printf("[insert_symbol] max symbol size exceeded by %d\n", ret - MAX_SYMBOL_SIZE + 1);
+    free(e);
+    return alloc_nil();
+  }
 
+  e->cell = cell;
   //printf("[insert_symbol] %s entry at %p (cell: %p)\r\n",symbol->ar.addr,e,e->cell);
   sm_put(*env, e->name, e);
 

--- a/sledge/minilisp.h
+++ b/sledge/minilisp.h
@@ -63,6 +63,7 @@
 #define MAX_EVAL_DEPTH 10000
 #define SYM_INIT_BUFFER_SIZE 32
 #define BIGNUM_INIT_BUFFER_SIZE 32
+#define MAX_SYMBOL_SIZE 64
 
 #define ERR_SYNTAX 0
 #define ERR_MAX_EVAL_DEPTH 1
@@ -94,7 +95,7 @@ int is_nil(Cell* c);
 
 typedef struct env_entry {
   Cell* cell;
-  char name[64];
+  char name[MAX_SYMBOL_SIZE];
 } env_entry;
 
 #define car(x) (x?(Cell*)((Cell*)x)->ar.addr:NULL)


### PR DESCRIPTION
I'm not too happy with allocating `nil` here, but it beats returning `NULL` (and getting a bogus cell warning).

Old behavior:

```
(def ffffffffffffffffffuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu 42)
(gc) ;=> segfault
```

New behavior:

```
(def ffffffffffffffffffuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu 42)
[insert_symbol] max symbol size exceeded by 6
nil
```