### PR TITLE
Remove trailing space in fn representation

### DIFF
--- a/sledge/writer.c
+++ b/sledge/writer.c
@@ -87,10 +87,10 @@ char* write_(Cell* cell, char* buffer, int in_list, int bufsize) {
       if (car(car(args))->tag == TAG_CONS) {
         Cell* arg_cell = car(car(args));
         // typed arg
-        ai += snprintf(tmp_args+ai, TMP_BUF_SIZE-ai, "(%s %s) ", (char*)(car(arg_cell)->ar.addr), (char*)(car(cdr(arg_cell))->ar.addr));
+        ai += snprintf(tmp_args+ai, TMP_BUF_SIZE-ai, ai ? " (%s %s)" : "(%s %s)", (char*)(car(arg_cell)->ar.addr), (char*)(car(cdr(arg_cell))->ar.addr));
       } else {
         // untyped arg
-        ai += snprintf(tmp_args+ai, TMP_BUF_SIZE-ai, "%s ", (char*)(car(car(args)))->ar.addr);
+        ai += snprintf(tmp_args+ai, TMP_BUF_SIZE-ai, ai ? " %s" : "%s" , (char*)(car(car(args)))->ar.addr);
       }
       args = cdr(args);
     }


### PR DESCRIPTION
Before:

    interim> (def foo (fn x y 42))
    (fn x y  42)

After:

    interim> (def foo (fn x y 42))
    (fn x y 42)